### PR TITLE
Updates to the build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,51 +24,82 @@ jobs:
         name: Prepare
         id: prepare
         run: |
-          DOCKER_USERNAME=buildsocietybot
-          DOCKER_IMAGE=buildsociety/nebula
-          DOCKER_PLATFORMS=linux/amd64,linux/386,linux/ppc64le,linux/arm/6,linux/arm/7,linux/arm64
+          DOCKER_USERNAME=$(if [ -z "${{ secrets.DOCKER_USERNAME }}" ]; then echo buildsocietybot; else echo ${{ secrets.DOCKER_USERNAME }}; fi)
+          DOCKER_IMAGE=${{ github.actor }}/nebula
+          DOCKER_IMAGE_CERT=${{ github.actor }}/nebula-cert
+          DOCKER_PLATFORMS=linux/amd64,linux/386,linux/ppc64le,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           VERSION=$(curl --silent "https://api.github.com/repos/slackhq/nebula/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
 
-          TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+
+          TAGS_CERT="${DOCKER_IMAGE_CERT}:${VERSION}"
+          TAGS_CERT="$TAGS_CERT,${DOCKER_IMAGE_CERT}:latest"
 
           echo ::set-output name=docker_username::${DOCKER_USERNAME}
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=docker_image_cert::${DOCKER_IMAGE_CERT}
           echo ::set-output name=version::${VERSION}
-          echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
-            --build-arg VERSION=$(curl --silent "https://api.github.com/repos/slackhq/nebula/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")') \
-            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-            --build-arg VCS_REF=${GITHUB_SHA::8} \
-            ${TAGS} --file Dockerfile .
+          echo ::set-output name=docker_platforms::${DOCKER_PLATFORMS}
+          BUILDX_ARGS=$( \
+            echo VERSION=${VERSION}; \
+            echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ'); \
+            echo VCS_REF=${GITHUB_SHA::8} )
+          BUILDX_ARGS="${BUILDX_ARGS//$'\n'/'%0A'}"
+          echo ::set-output name=buildx_args::${BUILDX_ARGS}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=tags_cert::${TAGS_CERT}
+      -
+        name: QEMU
+        uses: docker/setup-qemu-action@v1.1.0
       -
         name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3.2.0
+        uses: docker/setup-buildx-action@v1.3.0
       -
         name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2.3.4
       -
         name: Docker Buildx (build)
-        run: |
-          docker buildx build --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+        uses: docker/build-push-action@v2.4.0
+        with:
+          file: Dockerfile
+          build-args: ${{ steps.prepare.outputs.buildx_args }}
+          context: .
+          push: false
+          platforms: ${{ steps.prepare.outputs.docker_platforms }}
+          tags: ${{ steps.prepare.outputs.tags }}
       -
         name: Docker Login
         if: success() && github.event_name != 'pull_request' && (endsWith(github.ref, github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${{ steps.prepare.outputs.docker_username }}" --password-stdin
+        uses: docker/login-action@v1.9.0
+        with:
+          username: ${{ steps.prepare.outputs.docker_username }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       -
-        name: Docker Buildx (push)
+        name: Docker Buildx (push) - nebula
         if: success() && github.event_name != 'pull_request' && (endsWith(github.ref, github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        run: |
-          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+        uses: docker/build-push-action@v2.4.0
+        with:
+          file: Dockerfile
+          build-args: ${{ steps.prepare.outputs.buildx_args }}
+          context: .
+          push: true
+          platforms: ${{ steps.prepare.outputs.docker_platforms }}
+          tags: ${{ steps.prepare.outputs.tags }}
+      -
+        name: Docker Buildx (push) - nebula-cert
+        if: success() && github.event_name != 'pull_request' && (endsWith(github.ref, github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
+        uses: docker/build-push-action@v2.4.0
+        with:
+          file: nebula-cert.Dockerfile
+          build-args: ${{ steps.prepare.outputs.buildx_args }}
+          context: .
+          push: true
+          platforms: ${{ steps.prepare.outputs.docker_platforms }}
+          tags: ${{ steps.prepare.outputs.tags_cert }}
       -
         name: Docker Check Manifest
         if: success() && github.event_name != 'pull_request' && (endsWith(github.ref, github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
         run: |
           docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
-      -
-        name: Clear
-        if: always() && github.event_name != 'pull_request' && (endsWith(github.ref, github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        run: |
-          rm -f ${HOME}/.docker/config.json
+          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image_cert }}:${{ steps.prepare.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           BUILDX_ARGS=$( \
             echo VERSION=${VERSION}; \
             echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ'); \
-            echo VCS_REF=${GITHUB_SHA::8} )
+            echo VCS_REF=${GITHUB_SHA::8})
           BUILDX_ARGS="${BUILDX_ARGS//$'\n'/'%0A'}"
           echo ::set-output name=buildx_args::${BUILDX_ARGS}
           echo ::set-output name=tags::${TAGS}

--- a/nebula-cert.Dockerfile
+++ b/nebula-cert.Dockerfile
@@ -11,9 +11,9 @@ RUN printf "I am running on ${BUILDPLATFORM:-linux/amd64}, building for ${TARGET
     && rm -rf /tmp/* /var/cache/apk/* \
     && git -c advice.detachedHead=false clone --branch ${VERSION} https://github.com/slackhq/nebula /go/src/github.com/slackhq/nebula \
     && cd /go/src/github.com/slackhq/nebula \
-    && make BUILD_NUMBER="${VERSION#v}" build/$(echo ${TARGETPLATFORM:-linux/amd64} | sed -e "s/\/v/-/g" -e "s/\//-/g")/nebula \
+    && make BUILD_NUMBER="${VERSION#v}" build/$(echo ${TARGETPLATFORM:-linux/amd64} | sed -e "s/\/v/-/g" -e "s/\//-/g")/nebula-cert \
     && mkdir -p /go/build/${TARGETPLATFORM:-linux/amd64} \
-    && mv /go/src/github.com/slackhq/nebula/build/$(echo ${TARGETPLATFORM:-linux/amd64} | sed -e "s/\/v/-/g" -e "s/\//-/g")/nebula /go/build/${TARGETPLATFORM:-linux/amd64}/
+    && mv /go/src/github.com/slackhq/nebula/build/$(echo ${TARGETPLATFORM:-linux/amd64} | sed -e "s/\/v/-/g" -e "s/\//-/g")/nebula-cert /go/build/${TARGETPLATFORM:-linux/amd64}/
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:latest
 
@@ -29,14 +29,13 @@ LABEL maintainer="buildsociety" \
       org.opencontainers.image.version=$VERSION \
       org.opencontainers.image.revision=$VCS_REF \
       org.opencontainers.image.vendor="buildsociety" \
-      org.opencontainers.image.title="nebula" \
+      org.opencontainers.image.title="nebula-cert" \
       org.opencontainers.image.description="Nebula is a scalable overlay networking tool with a focus on performance, simplicity and security from Slack" \
       org.opencontainers.image.licenses="MIT"
 
-COPY --from=builder /go/build/${TARGETPLATFORM:-linux/amd64}/nebula /usr/local/bin/nebula
-RUN nebula -version
+COPY --from=builder /go/build/${TARGETPLATFORM:-linux/amd64}/nebula-cert /usr/local/bin/nebula-cert
+RUN nebula-cert -version
 
 VOLUME ["/config"]
 
-ENTRYPOINT [ "/usr/local/bin/nebula" ]
-CMD ["-config", "/config/config.yaml"]
+ENTRYPOINT [ "/usr/local/bin/nebula-cert" ]


### PR DESCRIPTION
## Description:

Hi, would you be interested in a pull request? I was recently in need of a `nebula` container, found yours and updated a couple of things:

* Changed from https://github.com/crazy-max/ghaction-docker-buildx to https://github.com/docker/setup-buildx-action (the former is discontinued with the latter gaining traction) and started using https://github.com/docker/build-push-action (results in a more readable step config)
* Replaced the Docker login step with https://github.com/docker/login-action (it also handles clearing of the credentials automatically - regardless of the outcome of the steps following it)
* Switched to using QEMU (https://github.com/docker/setup-qemu-action) for cross-platform builds, which allowed me to skip using `tonistiigi/xx:golang`
* Updated from Go 1.14 to 1.16, which made the container slightly smaller
* Added a (separate) `nebula-cert` container, mostly to ease getting the right executable
* Skipped `gcc` & `make` packages (since they're included under `build-base`)
* Squashed one git warning (with `-c advice.detachedHead=false`)

I'm happy to give you more info if you like.

## Benefits of this PR and context:

Since some of the build pipeline actions were discontinued it makes sense to replace them with ones backed by an org and a growing community - it should ensure operational continuity of the builds for any future nebula releases.

## How Has This Been Tested?

Using (amd64 image) in production in a lab environment didn't surface any issues (neither related to runtime stability nor to config compatibility).

## Source / References

https://github.com/docker/login-action
https://github.com/docker/setup-qemu-action
https://github.com/docker/setup-buildx-action
https://github.com/docker/build-push-action