### PR TITLE
Accounted for the possible difference between the acting user and the repo owner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
         id: prepare
         run: |
           DOCKER_USERNAME=$(if [ -z "${{ secrets.DOCKER_USERNAME }}" ]; then echo buildsocietybot; else echo ${{ secrets.DOCKER_USERNAME }}; fi)
-          DOCKER_IMAGE=${{ github.actor }}/nebula
-          DOCKER_IMAGE_CERT=${{ github.actor }}/nebula-cert
+          DOCKER_IMAGE=${{ github.repository }}
+          DOCKER_IMAGE_CERT=${{ github.repository }}-cert
           DOCKER_PLATFORMS=linux/amd64,linux/386,linux/ppc64le,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           VERSION=$(curl --silent "https://api.github.com/repos/slackhq/nebula/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
 


### PR DESCRIPTION
## Description:

Hi @matthewgall 

In my [original PR](https://github.com/buildsociety/nebula/pull/5) I did not take into account that the acting GitHub user may well be different than the owner of the repo. The fix is simple - instead of:

```
          DOCKER_IMAGE=${{ github.actor }}/nebula
          DOCKER_IMAGE_CERT=${{ github.actor }}/nebula-cert
```

I should have placed:

```
          DOCKER_IMAGE=${{ github.repository }}
          DOCKER_IMAGE_CERT=${{ github.repository }}-cert
```

## Benefits of this PR and context:

Fixes the broken build.

## How Has This Been Tested?

By running the GitHub Action build script on my fork.

## Source / References

N/A